### PR TITLE
php7: Migrate the role to be able to use php7 version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -119,7 +119,8 @@ php_fpm_pool_defaults:
   pm.status_path: "/fpm-status"
   ping.path: "/fpm-ping"
 
-php_slowlog_path: /var/log/php5-slow.log
+fpm_reopenlogs_path: /usr/lib/php5/php5-fpm-reopenlogs
+php_slowlog_path: /var/log/php-slow.log
 php_fpm_pools:
   - name: www-data
     user: www-data

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -6,7 +6,7 @@
     follow: true
   with_items:
     - "{{ php_conf_path }}"
-    - "{{ php_extension_conf_path }}"
+    - "{{ php_extension_conf_paths }}"
 
 - name: Place PHP configuration file in place.
   template:
@@ -23,7 +23,7 @@
 - name: Place PHP CLI configuration file in place.
   template:
     src: php.ini.j2
-    dest: "/etc/php5/cli/php.ini"
+    dest: "{{ php_conf_path }}/cli/php.ini"
     owner: root
     group: root
     mode: 0644
@@ -31,7 +31,7 @@
   when: php_use_managed_ini
 
 - name: Changing php umask
-  lineinfile: dest=/etc/init/php5-fpm.conf line="umask 0002"
+  lineinfile: dest="/etc/init/{{php_fpm_daemon}}.conf" line="umask 0002"
   when: php_enable_php_fpm
 
 - name: Place PHP configuration file in place for php-fpm.
@@ -48,24 +48,27 @@
 - name: Place APC configuration file in place.
   template:
     src: apc.ini.j2
-    dest: "{{ php_extension_conf_path }}/{{ php_apc_conf_filename }}"
+    dest: "{{ item }}/{{ php_apc_conf_filename }}"
     owner: root
     group: root
     force: yes
     mode: 0644
   when: php_enable_apc
   notify: restart webserver
+  with_items: "{{ php_extension_conf_paths }}"
+
 
 - name: Place OpCache configuration file in place.
   template:
     src: opcache.ini.j2
-    dest: "{{ php_extension_conf_path }}/{{ php_opcache_conf_filename }}"
+    dest: "{{ item }}/{{ php_opcache_conf_filename }}"
     owner: root
     group: root
     force: yes
     mode: 0644
   when: php_opcache_enable
   notify: restart webserver
+  with_items: "{{ php_extension_conf_paths }}"
 
 - name: Delete default pool
   file: path={{ php_conf_path }}/fpm/pool.d/www.conf state=absent

--- a/tasks/logrotate.yml
+++ b/tasks/logrotate.yml
@@ -1,3 +1,12 @@
+- name: Check that fpm_reopenlogs_path exist.
+  stat:
+    path: "{{fpm_reopenlogs_path}}"
+  register: _reopenlog
+
+- fail:
+    msg: "You have defined php_slowlog_path, who require valid path fpm_reopenlogs_path for logrotate"
+  when: not _reopenlog.stat.exists
+
 - name: Configure logrotate for php slowlog
   template:
     src: logrotate-slowlog.conf.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,15 +13,20 @@
     php_webserver_daemon: "{{ __php_webserver_daemon }}"
   when: php_webserver_daemon is not defined
 
+- name: Define php_fpm_daemon.
+  set_fact:
+    php_fpm_daemon: "{{ __php_fpm_daemon }}"
+  when: php_fpm_daemon is not defined
+
 - name: Define php_conf_path.
   set_fact:
     php_conf_path: "{{ __php_conf_path }}"
   when: php_conf_path is not defined
 
-- name: Define php_extension_conf_path.
+- name: Define php_extension_conf_paths.
   set_fact:
-    php_extension_conf_path: "{{ __php_extension_conf_path }}"
-  when: php_extension_conf_path is not defined
+    php_extension_conf_paths: "{{ __php_extension_conf_paths }}"
+  when: php_extension_conf_paths is not defined
 
 # Setup/install tasks.
 - include: setup-RedHat.yml
@@ -50,3 +55,4 @@
 
 # Configure Logrotate
 - include: logrotate.yml
+  when: php_enable_php_fpm

--- a/templates/logrotate-slowlog.conf.j2
+++ b/templates/logrotate-slowlog.conf.j2
@@ -8,6 +8,6 @@
         compress
         delaycompress
         postrotate
-                /usr/lib/php5/php5-fpm-reopenlogs
+                {{fpm_reopenlogs_path}}
         endscript
 }

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -15,9 +15,10 @@ __php_packages:
 __php_webserver_daemon: "apache2"
 
 # Vendor-specific configuration paths on Debian/Ubuntu make my brain asplode.
+
 __php_conf_path: "{{ '/etc/php5' if php_webserver_daemon and php_webserver_daemon != 'apache2' else '/etc/php5/apache2' }}"
-__php_extension_conf_path: "{{ __php_conf_path }}/conf.d"
+__php_extension_conf_paths: ["{{ __php_conf_path }}/conf.d"]
+__php_fpm_daemon: php5-fpm
 
 php_apc_conf_filename: 20-apc.ini
 php_opcache_conf_filename: 05-opcache.ini
-php_fpm_daemon: php5-fpm

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -18,7 +18,7 @@ __php_packages:
 __php_webserver_daemon: "httpd"
 
 __php_conf_path: /etc
-php_extension_conf_path: /etc/php.d
+php_extension_conf_paths: ["/etc/php.d"]
 
 php_apc_conf_filename: apc.ini
 php_opcache_conf_filename: opcache.ini


### PR DESCRIPTION
Fix some php5 static strings
Also php7 extension conf path are no longer a link to /etc/php5/conf.d
(.../cli/conf.d, .../fpm/conf.d)

Now directory like `.../fpm/conf.d` are simple directory, not a link to `/etc/php5/conf.d`

So add a way to specify an array of conf path instead of a simple string.

It will allow us to work with both way. Default value remain the same path