### PR TITLE
aws_elasticache: Add AWS elasticache memcached client

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -95,3 +95,6 @@ php_fpm_pool_defaults:
 php_session_save_handler: files
 php_session_save_path: ""
 php_session_cookie_domain: ""
+
+# This extension is compiled and seems to work only on debian. Ubuntu is failing to compile it
+php_aws_elasticache: false

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -63,6 +63,7 @@ provisioner:
         php_version_to_install: 5
         php_debian_pkg_managed: true
         php_enable_webserver: false
+        php_aws_elasticache: true
       debian-php7:
         php_version_to_install: 7.1
         php_debian_pkg_managed: true
@@ -70,6 +71,7 @@ provisioner:
           - deb https://packages.sury.org/php/ stretch main
         php_debian_pkg_key: https://packages.sury.org/php/apt.gpg
         php_enable_webserver: false
+        php_aws_elasticache: true
       ubuntu-php7:
         php_version_to_install: 7.2
         php_enable_webserver: false

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -79,3 +79,9 @@ def test_packages(host):
         for package in present:
             p = host.package(package)
             assert p.is_installed
+
+
+def test_aws_elasticache(host):
+    if 'php_aws_elasticache' in host.ansible.get_variables():
+        cmd = host.run('php -r "if (!extension_loaded(\'memcached\')) { exit(1); }"')
+        assert cmd.rc == 0

--- a/tasks/aws-elasticache.yml
+++ b/tasks/aws-elasticache.yml
@@ -1,0 +1,121 @@
+---
+- name: Ensure dev packages are installed.
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - zlib1g-dev
+    - pkg-config
+    - libevent-dev
+    - gcc
+    - g++
+    - make
+    - autoconf
+    - libsasl2-dev
+    - git
+
+- name: Install php-igbinary if PHP>5.
+  apt:
+    name: "php-igbinary"
+    state: present
+  when: php_version_to_install != 5
+
+- name: Install php-igbinary if PHP5.
+  apt:
+    name: "php5-igbinary"
+    state: present
+  when: php_version_to_install == 5
+
+- name: Check that /usr/local/src/aws-libmemcached exist
+  stat:
+    path: /usr/local/src/aws-libmemcached
+  register: _aws_libmemcached
+
+- name: Clone the aws-libmemcached repo.
+  git:
+    repo: https://github.com/awslabs/aws-elasticache-cluster-client-libmemcached
+    dest: /usr/local/src/aws-libmemcached
+    version: master
+    accept_hostkey: yes
+    depth: 1
+  when: not _aws_libmemcached.stat.exists
+
+- name: Clone the aws-elasticache repo for php5.
+  git:
+    repo: https://github.com/awslabs/aws-elasticache-cluster-client-memcached-for-php
+    dest: /usr/local/src/aws-elasticache
+    version: master
+    accept_hostkey: yes
+    depth: 1
+  when: php_version_to_install == 5
+
+- name: Clone the aws-elasticache repo for php7.
+  git:
+    repo: https://github.com/awslabs/aws-elasticache-cluster-client-memcached-for-php
+    dest: /usr/local/src/aws-elasticache
+    version: php7
+    accept_hostkey: yes
+    depth: 1
+  when: php_version_to_install != 5
+
+- name: Fix for libmemcached library and autoconf
+  file:
+    path: "{{ item }}"
+    state: touch
+    mode: "u=rwx,g=rx,o=rx"
+  with_items:
+    - /usr/local/src/aws-libmemcached/configure.ac
+    - /usr/local/src/aws-libmemcached/aclocal.m4
+    - /usr/local/src/aws-libmemcached/configure
+    - /usr/local/src/aws-libmemcached/Makefile.am
+    - /usr/local/src/aws-libmemcached/Makefile.in
+  when: not _aws_libmemcached.stat.exists
+
+- name: Run configure script on libmemcached.
+  command: >
+    ./configure --with-libmemcached-dir=/usr/local/ --disable-memcached-sasl
+    chdir=/usr/local/src/aws-libmemcached
+    creates=/usr/local/bin/memstat
+
+- name: Make and install libmemcached.
+  command: >
+    {{ item }}
+    chdir=/usr/local/src/aws-libmemcached
+    creates=/usr/local/bin/memstat
+  with_items:
+    - make
+    - make install
+
+- name: Run phpize.
+  command: >
+    phpize
+    chdir=/usr/local/src/aws-elasticache
+    creates={{ php_extension_conf_paths[0] }}/{{ php_aws_memcached_conf_filename }}
+
+- name: Run configure script for elasticache client.
+  command: >
+    ./configure --with-libmemcached-dir=/usr/local/ --enable-memcached-igbinary
+    chdir=/usr/local/src/aws-elasticache
+    creates={{ php_extension_conf_paths[0] }}/{{ php_aws_memcached_conf_filename }}
+
+- name: Make and install elasticache client.
+  command: >
+    {{ item }}
+    chdir=/usr/local/src/aws-elasticache
+    creates={{ php_extension_conf_paths[0] }}/{{ php_aws_memcached_conf_filename }}
+  with_items:
+    - make
+    - make install
+
+- name: Ensure the aws-memcached.ini is installed in PHP configuration
+  template:
+    src: aws-memcached.ini.j2
+    dest: "{{ item }}/{{ php_aws_memcached_conf_filename }}"
+    owner: root
+    group: root
+    force: yes
+    mode: 0644
+  notify:
+    - restart webserver
+    - restart php-fpm
+  with_items: "{{ php_extension_conf_paths }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,6 +61,11 @@
 # Configure PHP.
 - include: configure.yml
 
+# Configure AWS Elasticache.
+- include: aws-elasticache.yml
+  when: php_aws_elasticache
+
+
 # Configure Logrotate
 - include: logrotate.yml
   when: php_enable_php_fpm

--- a/templates/aws-memcached.ini.j2
+++ b/templates/aws-memcached.ini.j2
@@ -1,0 +1,4 @@
+; {{ ansible_managed }}
+; This file load the memcached extension compiled for AWS
+extension=memcached.so
+memcached.serializer=igbinary

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -19,3 +19,4 @@ __php_fpm_daemon: php{{php_version_to_install}}-fpm
 
 php_apc_conf_filename: 20-apc.ini
 php_opcache_conf_filename: 05-opcache.ini
+php_aws_memcached_conf_filename: 30-aws-memcached.ini


### PR DESCRIPTION
This commit add the elasticache memcached client.
The setup is a bit complex, it need to be compiled and AWS doesn't really maintain this library.
It's working well on debian (tested with molecule) but doesn't work with ubuntu.

A parameter in the default can be overrided to setup this library easily.