### PR TITLE
reopenlogs: Fix the variable precedence of ansible

### DIFF
--- a/tasks/logrotate.yml
+++ b/tasks/logrotate.yml
@@ -1,12 +1,12 @@
 - name: Setting reopenlogs path
   set_fact:
     fpm_reopenlogs_path: /usr/lib/php5/php5-fpm-reopenlogs
-  when: php_version_to_install == 5
+  when: php_version_to_install == 5 and fpm_reopenlogs_path is not defined
 
 - name: Setting reopenlogs path
   set_fact:
     fpm_reopenlogs_path: /usr/lib/php/php{{php_version_to_install}}-fpm-reopenlogs
-  when: php_version_to_install > 5
+  when: php_version_to_install > 5 and fpm_reopenlogs_path is not defined
 
 - name: Check that fpm_reopenlogs_path exist.
   stat:


### PR DESCRIPTION
Because of the variable precedence, a set_facts takeover the variable defined for fpm_reopenlogs_path.
I added a condition to check if the variable is already defined (forced), else, we set the facts