### PR TITLE
apt: adding ignore error on update to avoid fail when apt keyu changed during ASG startup

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -11,6 +11,7 @@
 
 - name: Update apt cache.
   apt: update_cache=yes cache_valid_time=86400
+  ignore_errors: yes
 
 - name: Ensure PHP packages are installed.
   apt:


### PR DESCRIPTION
apt: adding ignore error on update to avoid fail when apt keyu changed during ASG startup