### PR TITLE
Ignore error if /etc/init/{{ php_fpm_daemon }}.conf file is missing

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -38,6 +38,7 @@
   lineinfile:
     path: "/etc/init/{{ php_fpm_daemon }}.conf"
     line: "umask 0002"
+  ignore_errors: yes
   when: php_enable_php_fpm
 
 - name: Place PHP FPM configuration file in place for php-fpm.


### PR DESCRIPTION
A customer is using PHP 7.4 from `ppa:ondrej/php`, that file is not there anymore.