### PR TITLE
Make serialize_precision configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,6 +60,7 @@ php_auto_prepend_file: ""
 php_date_timezone: "America/Chicago"
 php_cache_expire: "180"
 php_gc_maxlifetime: "1440"
+php_serialize_precision: "17"
 
 php_sendmail_path: "/usr/sbin/sendmail -t -i"
 php_short_open_tag: false

--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -15,7 +15,7 @@ zlib.output_compression = Off
 
 implicit_flush = Off
 unserialize_callback_func =
-serialize_precision = 17
+serialize_precision = {{ php_serialize_precision }}
 disable_functions = {{ php_disable_functions }}
 disable_classes =
 


### PR DESCRIPTION
Hi,

I'm not sure if you are accepting pull request, I didn't find anything in the readme
For our stack, we needed the defaults setting for `serialize_precision` (-1), but it is not configurable.
I left your default (17) to not break anything.
I've forked the repo for now on our side so we have a working solution, but it might be useful for others.

Let me know
